### PR TITLE
Added swaggerDocs at /swagger

### DIFF
--- a/server/newconnectionwhodis/urls.py
+++ b/server/newconnectionwhodis/urls.py
@@ -1,7 +1,23 @@
 from django.urls import path, include
 from .views import *
+from rest_framework import permissions
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
 
 SERVICE = "api/v1/"
+
+schema_view = get_schema_view(
+   openapi.Info(
+      title="NewConnenction APIs",
+      default_version='v1',
+      description="Test description",
+      terms_of_service="Apache License 2.0",
+      contact=openapi.Contact(email="contact@snippets.local"),
+      license=openapi.License(name="Apache License 2.0"),
+   ),
+   public=True,
+   permission_classes=[permissions.AllowAny],
+)
 
 urlpatterns = [
     path(
@@ -56,4 +72,6 @@ urlpatterns = [
         name="comment-likes",
     ),
     path(f"{SERVICE}author/<str:author_id>/inbox/", InboxView.as_view(), name="inbox"),
+
+    path('swagger', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
 ]

--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -52,6 +52,8 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+
+    'drf_yasg',
 ]
 
 SITE_ID = 1


### PR DESCRIPTION
Adding the docs was way easier than I thought. I still need to test it out though and check if any any fields need to be added to the docs (if we want to use actually use Swagger to test out the APIs, rather than just viewing them for reference)

![screencapture-localhost-8000-swagger-2021-11-13-16_32_47](https://user-images.githubusercontent.com/44443467/141662052-16089e6f-6485-4649-8d1c-5be25fc1d41a.png)

